### PR TITLE
fix update body

### DIFF
--- a/routes/issues.js
+++ b/routes/issues.js
@@ -91,7 +91,7 @@ router.put("/:id", async (req, res) => {
     // }
     const issue = await Issue.updateOne(
       { _id: id },
-      { $set: JSON.parse(req.body.data) }
+      { $set: req.body }
     );
     res.status(200).json(issue);
   } catch (error) {


### PR DESCRIPTION
For a PUT request with `content-type: application/json` express already parses the request body. So it's enough to use the `req.body` object instead of parsing a string in the `data` field

Example of request:
```
PUT /issues/63beba993c66f5af6bd19432
Body: {
    "location": {
        "latitude": 40.5,
        "longitude": -120.1
    }
}
```